### PR TITLE
Support for registered claims nbf, exp, iss, aud.

### DIFF
--- a/jwt.cfc
+++ b/jwt.cfc
@@ -58,13 +58,13 @@
 		<!--- Verify claims --->
 		<cfif StructKeyExists(payload,"exp") and not variables.ignoreExpiration>
 			<cfset var exp=DateAdd("s",payload.exp,DateConvert("utc2Local","January 1 1970 00:00"))>
-			<cfif exp gt now()>
+			<cfif exp lt now()>
 				<cfthrow type="Invalid Token" message="Signature verification failed: Token expired">
 			</cfif>
 		</cfif>
 		<cfif StructKeyExists(payload,"nbf")>
 			<cfset var nbf=DateAdd("s",payload.nbf,DateConvert("utc2Local","January 1 1970 00:00"))>
-			<cfif nbf lt now()>
+			<cfif nbf gt now()>
 				<cfthrow type="Invalid Token" message="Signature verification failed: Token not yet active">
 			</cfif>
 		</cfif>

--- a/readme.md
+++ b/readme.md
@@ -16,3 +16,14 @@ This is a port of the node.js project [node-jwt-simple](https://github.com/hokac
 	<!--- Decode the token and get the data structure back. This is will throw an error if the token is invalid --->
 	<cfset result = jwt.decode(token)>
 
+## Support for registered claims
+
+This CFC supports the `nbf` and `exp` registered claims that can be part of the payload. Verification of the token will fail if the token is not yet active or if the token is expired according to the `nbf` and `exp` claims. They should be numeric dates in Unix epoch time according to the JWT spec.
+
+To ignore the `exp` claim during verification, pass `ignoreExpiration=true` when instantiating the CFC. For example:
+
+	<cfset jwt = new jwt(key=secretkey, ignoreExpiration=true)>
+
+This CFC also supports the `aud` and `iss` registered claims during verification. If you don't pass `audience` or `issuer` during instantiation, the claims will be ignored during verification. If you do pass them, they'll be included during the verification process. Here's an example:
+
+	<cfset jwt = new jwt(key=secretkey, audience="myaudiencevalue", issuer="myissuervalue")>


### PR DESCRIPTION
The expiration (exp), not-before-date (nbf), issuer (iss), and audience (aud) claims are standard registered claims. This pull request adds support for these claims as part of the signature verification process. 

The intention of this project is to mirror the node-jwt-simple project. That project now supports the nbf and exp claims, so this pull request brings it into alignment with that functionality in the node-jwt-simple project.

The issuer and audience claims are not in the node-jwt-simple project but are simple to implement and are not enforced if not provided in the constructor/init. 

The ignoreExpiration argument provides a way for the exp claim to be ignored even if one is provided in the payload.

Thank you very much for writing this project, it’s been helpful for me in implementing some JWT stuff with our internal projects. These enhancements were necessary to meet my projects’ needs so I figured I’d pass the enhancements along. I hope you approve and implement them in your project. Take care!  - Josh Curtiss